### PR TITLE
Optimize schedule further by minimizing class count

### DIFF
--- a/doSchedule.py
+++ b/doSchedule.py
@@ -173,7 +173,15 @@ def build_model(data, limits):
         model.AddMaxEquality(block_used[b], [class_used[(b, s, t)] for s, t in pairs])
 
     model.Add(sum(block_used[b] for b in range(B)) <= limits["MAX_BLOCKS"])
-    model.Minimize(sum(block_used[b] for b in range(B)))
+
+    # Optimise primarily for minimum number of blocks and secondarily for
+    # minimum number of classes to reduce teacher hours.  To achieve this we
+    # use a weighted objective where the block count has a dominant weight that
+    # exceeds any possible number of classes.
+    num_blocks = sum(block_used[b] for b in range(B))
+    num_classes = sum(class_used[(b, s, t)] for b in range(B) for s, t in pairs)
+    big_M = B * limits["MAX_CLASSES_PER_BLOCK"] + 1
+    model.Minimize(num_blocks * big_M + num_classes)
 
     return model, y, class_used, block_used, B, pairs, students
 

--- a/solver.py
+++ b/solver.py
@@ -163,8 +163,11 @@ def build_model(data, limits):
     # 6) MAX_BLOCKS
     model.Add(sum(block_used[b] for b in range(B)) <= limits["MAX_BLOCKS"])
 
-    # --- Objective: minimise #used blocks -----------------------------------
-    model.Minimize(sum(block_used[b] for b in range(B)))
+    # --- Objective: minimise blocks first, then number of classes -------------
+    num_blocks = sum(block_used[b] for b in range(B))
+    num_classes = sum(class_used[(b, s, t)] for b in range(B) for s, t in pairs)
+    big_M = B * limits["MAX_CLASSES_PER_BLOCK"] + 1
+    model.Minimize(num_blocks * big_M + num_classes)
 
     return model, y, class_used, block_used, B, pairs, students
 


### PR DESCRIPTION
## Summary
- tweak the optimisation in `doSchedule.py` and `solver.py`
- keep minimising block usage but also minimise number of classes when block count is the same

## Testing
- `python -m py_compile doSchedule.py solver.py`

------
https://chatgpt.com/codex/tasks/task_e_685da04fcc08832fb21733ea8f6d19be