### PR TITLE
Add optimisation objective modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Copy `config-example.json` to `schedule-config.json` and adjust it to match your
 - `days` – list of days and available lesson slots.
 - `cabinets` – available rooms with capacities.
 - `subjects`, `teachers`, `students` – information about who studies or teaches what.
+- `model` – solver parameters. `objective` controls optimisation strategy:
+  - `total` (default) minimises the sum of all penalties.
+  - `fair` minimises the largest individual penalty among teachers and students.
 
 ### 4. Run the scheduler
 

--- a/config-example.json
+++ b/config-example.json
@@ -60,7 +60,8 @@
   "model": {
     "maxTime": 1500,
     "workers": 10,
-    "showProgress": true
+    "showProgress": true,
+    "objective": "total"
   },
   
 }


### PR DESCRIPTION
## Summary
- support `objective` setting in the model block
- allow two modes: `total` for classic sum of penalties and `fair` to minimise the worst person’s penalty
- document the new option in README
- update example configuration with the new parameter

## Testing
- `python -m py_compile newSchedule.py`
- `pip install ortools` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d29412c40832f8d389e700f280033