### PR TITLE
Update config structure

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -34,21 +34,21 @@
   },
 
   "subjects": {
-    "DP1_English_Literature_SL": { "classes": [2, 1], "cabinets": ["Room #001", "Room #002"], "optimalSlot": 4, "comment": "Literary analysis benefits from stabilized verbal processing later in the day." },
-    "DP1_English_Literature_HL": { "classes": [2, 2, 1], "optimalSlot": 4, "comment": "Extended essay work and close reading profit from early‑afternoon linguistic focus." },
+    "DP1_English_Literature_SL": { "teachers": ["Marie"], "optimalSlot": 4, "classes": [2, 1], "allowPermutations": false, "cabinets": ["Room #001", "Room #002"], "comment": "Literary analysis benefits from stabilized verbal processing later in the day." },
+    "DP1_English_Literature_HL": { "teachers": ["Marie"], "optimalSlot": 4, "classes": [2, 2, 1], "comment": "Extended essay work and close reading profit from early‑afternoon linguistic focus." },
 
-    "DP1_Mathematics_SL": { "classes": [2, 1], "optimalSlot": 0, "comment": "Problem‑solving is strongest first period when working‑memory and alertness are freshest.", "allowPermutations": false },
-    "DP1_Mathematics_HL": { "classes": [2, 2, 1], "optimalSlot": 0, "comment": "Higher‑level math needs peak cognitive resources available right at the start of the day." },
+    "DP1_Mathematics_SL": { "teachers": ["Alex"], "optimalSlot": 0, "classes": [2, 1], "allowPermutations": false, "comment": "Problem‑solving is strongest first period when working‑memory and alertness are freshest." },
+    "DP1_Mathematics_HL": { "teachers": ["Alex"], "optimalSlot": 0, "classes": [2, 2, 1], "comment": "Higher‑level math needs peak cognitive resources available right at the start of the day." },
 
-    "DP1_Chemistry_SL": { "classes": [2, 1], "optimalSlot": 1, "comment": "Hands‑on labs benefit from high alertness that persists through the second morning slot." },
-    "DP1_Chemistry_HL": { "classes": [2], "optimalSlot": 1, "comment": "Advanced chemistry calculations need strong focus still available early in the day." }
+    "DP1_Chemistry_SL": { "teachers": ["Olga"], "optimalSlot": 1, "classes": [2, 1], "comment": "Hands‑on labs benefit from high alertness that persists through the second morning slot." },
+    "DP1_Chemistry_HL": { "teachers": ["Olga"], "optimalSlot": 1, "classes": [2], "comment": "Advanced chemistry calculations need strong focus still available early in the day." }
   },
 
-  "teachers": [
-    { "importance": 50, "arriveEarly": true, "name": "Marie", "subjects": [ "DP1_English_Literature_SL", "DP1_English_Literature_HL" ] },
-    { "name": "Alex", "subjects": [ "DP1_Mathematics_SL", "DP1_Mathematics_HL" ] },
-    { "name": "Olga", "subjects": [ "DP1_Chemistry_SL", "DP1_Chemistry_HL" ] }
-  ],
+  "teachers": {
+    "Marie": { "importance": 50, "arriveEarly": true },
+    "Alex": {},
+    "Olga": {}
+  },
 
   "students": [
     { "name": "Mike",      "subjects": ["DP1_English_Literature_SL", "DP1_Mathematics_HL"] },


### PR DESCRIPTION
## Summary
- update config-example.json to store teachers per subject and teacher details in an object
- adapt `load_config` to convert the new format to the internal representation

## Testing
- `python newSchedule.py config-example.json schedule.json` *(fails: ModuleNotFoundError: No module named 'ortools')*

------
https://chatgpt.com/codex/tasks/task_e_687e41fa1ee0832f9616f1d8cc8e80f2