### PR TITLE
Add teacher availability limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Copy `config-example.json` to `schedule-config.json` and adjust it to match your
 - `days` – list of days and available lesson slots.
 - `cabinets` – available rooms with capacities.
 - `subjects`, `teachers`, `students` – information about who studies or teaches what.
+  Teachers may define `allowedSlots` and/or `forbiddenSlots` to restrict their availability.
 - `model` – solver parameters. `objective` controls optimisation strategy:
   - `total` (default) minimises the sum of all penalties.
   - `fair` minimises the largest individual penalty among teachers and students.

--- a/config-example.json
+++ b/config-example.json
@@ -45,9 +45,18 @@
   },
 
   "teachers": {
-    "Marie": { "importance": 50, "arriveEarly": true },
-    "Helena": {},
-    "Jane": {},
+    "Marie": {
+      "importance": 50,
+      "arriveEarly": true,
+      "allowedSlots": { "Tuesday": [], "Thursday": [4,5,6,7], "Friday": [] },
+      "forbiddenSlots": { "Tuesday": [3,4] }
+    },
+    "Helena": {
+      "allowedSlots": { "Monday": [], "Wednesday": [0,1,2,3,4] }
+    },
+    "Jane": {
+      "forbiddenSlots": { "Friday": [5,6] }
+    },
 
     "Alex": {},
     "Greg": {},


### PR DESCRIPTION
## Summary
- allow specifying allowedSlots and forbiddenSlots for teachers
- demonstrate all combinations in the example config
- mention the new settings in the README
- respect these limits in the optimisation model

## Testing
- `python -m py_compile newSchedule.py`
- `pip install ortools` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e65737954832fba60f9ed3c95265d