### PR TITLE
Support fixed lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Copy `config-example.json` to `schedule-config.json` and adjust it to match your
 - `cabinets` – available rooms with capacities.
 - `subjects`, `teachers`, `students` – information about who studies or teaches what.
   Teachers may define `allowedSlots` and/or `forbiddenSlots` to restrict their availability.
+- `lessons` – optional array of fixed lessons `[day, slot, subject, room, [teachers]]`.
 - `model` – solver parameters. `objective` controls optimisation strategy:
   - `total` (default) minimises the sum of all penalties.
   - `fair` minimises the largest individual penalty among teachers and students.

--- a/config-example.json
+++ b/config-example.json
@@ -76,6 +76,10 @@
       "subjects": ["DP1_English_Literature_SL", "DP1_Mathematics_SL", "DP1_Chemistry_SL" ] }
   ],
 
+  "lessons": [
+    ["Monday", 1, "DP1_English_Literature_SL", "Room #002", ["Marie", "Jane"]]
+  ],
+
   "model": {
     "maxTime": 1500,
     "workers": 10,


### PR DESCRIPTION
## Summary
- load `lessons` list from configuration
- validate pre-assigned lessons and integrate them in the solver
- document `lessons` section in README
- show example `lessons` block in config

## Testing
- `python newSchedule.py config-example.json output.json -y` *(fails: ModuleNotFoundError: No module named 'ortools')*

------
https://chatgpt.com/codex/tasks/task_e_687e7336c0c8832f93917f942fb0446d