### PR TITLE
Add allowed/forbidden slots for students

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ List of students with their subjects and optional settings.
 - `group` – number of students if this is a group entry
 - `importance` – overrides the default student weight
 - `arriveEarly` – whether the student arrives from the first slot
+- `allowedSlots` – specific slots when the student can attend
+- `forbiddenSlots` – slots the student cannot attend
 
 ### lessons
 Optional fixed lessons specified as `[day, slot, subject, room, [teachers]]` to lock classes to certain times.

--- a/config-example.json
+++ b/config-example.json
@@ -68,10 +68,24 @@
   },
 
   "students": [
-    { "name": "Mike",      "subjects": ["DP1_English_Literature_SL", "DP1_Mathematics_HL"] },
-    { "name": "Aleksander", "subjects": ["DP1_English_Literature_SL", "DP1_Mathematics_SL"] },
+    {
+      "name": "Mike",
+      "subjects": ["DP1_English_Literature_SL", "DP1_Mathematics_HL"],
+      "allowedSlots": { "Monday": [], "Wednesday": [0,1,2,3] }
+    },
+    {
+      "name": "Aleksander",
+      "subjects": ["DP1_English_Literature_SL", "DP1_Mathematics_SL"],
+      "forbiddenSlots": { "Friday": [5,6] }
+    },
     { "arriveEarly": false, "name": "Ekaterina",  "subjects": ["DP1_Mathematics_HL", "DP1_Chemistry_SL"] },
-    { "importance": 30, "name": "John", "subjects": ["DP1_Mathematics_HL", "DP1_Chemistry_HL"] },
+    {
+      "importance": 30,
+      "name": "John",
+      "subjects": ["DP1_Mathematics_HL", "DP1_Chemistry_HL"],
+      "allowedSlots": { "Tuesday": [] },
+      "forbiddenSlots": { "Monday": [0] }
+    },
     { "group": 10, "name": "Other students",
       "subjects": ["DP1_English_Literature_SL", "DP1_Mathematics_SL", "DP1_Chemistry_SL" ] }
   ],


### PR DESCRIPTION
## Summary
- support `allowedSlots` and `forbiddenSlots` for students
- document new student settings
- show usage in example config

## Testing
- `python -m py_compile newSchedule.py`
- `python -m json.tool config-example.json` *(validates JSON)*
- `pip install ortools` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687f3dd964fc832fa2ddd19f5626c842