### PR TITLE
Implement teacher weight in penalties

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The configuration file is divided into several sections. Values are stored as `[
 - **maxTeacherSlots** – maximum number of consecutive lessons a teacher can teach. A high number allows long stretches while a low one enforces frequent breaks. *(default 8)*
 - **maxStudentSlots** – maximum consecutive lessons for students. Large numbers mean longer days, small numbers insert more rest. *(default 6)*
 - **objective** – `"total"` minimises the sum of all penalties; `"fair"` tries to distribute penalties evenly. *(default `"total"`)*
+- **teacherAsStudents** – how many student opinions one teacher counts as when calculating penalties. *(default 15)*
 
 ### defaults (required)
 - **teacherImportance** – base weight for teachers. Higher values make teacher gaps more costly. *(default 20)*
@@ -101,10 +102,10 @@ The configuration file is divided into several sections. Values are stored as `[
 - **avoidConsecutive** – discourage placing the same subject on neighbouring days. *(default `true`)*
 
 ### penalties (required)
-- **gapTeacher** – penalty for idle teacher slots. High values reduce teacher free time, low values allow it. *(default 2)*
-- **gapStudent** – penalty for gaps in a student day. Raise to keep days compact. *(default 10)*
+- **gapTeacher** – penalty for idle teacher slots. High values reduce teacher free time, low values allow it. *(default 30)*
+- **gapStudent** – penalty for gaps in a student day. Raise to keep days compact. *(default 100)*
 - **unoptimalSlot** – penalty for each slot away from a subject's preferred time. Bigger values keep lessons closer to their optimum. *(default 1)*
-- **consecutiveClass** – penalty when the same subject appears on consecutive days. High numbers spread classes apart. *(default 15)*
+- **consecutiveClass** – penalty when the same subject appears on consecutive days. High numbers spread classes apart. *(default 10)*
 
 ### days
 List the days of teaching and available lesson numbers:

--- a/config-example.json
+++ b/config-example.json
@@ -2,7 +2,8 @@
   "settings": {
     "maxTeacherSlots": [6, "Maximum number of consecutive lessons a teacher can teach. High value allows long stretches, low value forces more breaks."],
     "maxStudentSlots": [6, "Maximum number of consecutive lessons a student can attend. Large number means longer school days without rest."],
-    "objective": ["total", "Optimisation goal: 'total' minimises all penalties, 'fair' balances penalties between teachers and students."]
+    "objective": ["total", "Optimisation goal: 'total' minimises all penalties, 'fair' balances penalties between teachers and students."],
+    "teacherAsStudents": [15, "How many student opinions a teacher counts for when calculating penalties"]
   },
   "defaults": {
     "teacherImportance": [20, "Default teacher weight in penalties. Higher value makes gaps for teachers more expensive."],
@@ -14,10 +15,10 @@
     "avoidConsecutive": [true, "Discourage scheduling the same subject on back-to-back days."]
   },
   "penalties": {
-    "gapTeacher": [2, "Penalty per empty slot in a teacher schedule. Higher values reduce teacher idle time."],
-    "gapStudent": [10, "Penalty per empty slot in a student day. Raise to keep days compact."],
+    "gapTeacher": [30, "Penalty per empty slot in a teacher schedule. Higher values reduce teacher idle time."],
+    "gapStudent": [100, "Penalty per empty slot in a student day. Raise to keep days compact."],
     "unoptimalSlot": [1, "Penalty for each slot away from the preferred time of a subject. Larger value pushes classes toward their optimal slot."],
-    "consecutiveClass": [15, "Penalty when a subject appears on consecutive days. High value spreads classes apart."]
+    "consecutiveClass": [10, "Penalty when a subject appears on consecutive days. High value spreads classes apart."]
   },
 
   "days": [


### PR DESCRIPTION
## Summary
- introduce `teacherAsStudents` setting to weigh teacher feedback
- adjust penalty formulas for unoptimal slot and consecutive classes
- update HTML output to mark teacher penalties correctly
- revise example configuration with new values
- document new setting and updated penalty defaults in README

## Testing
- `python -m py_compile newSchedule.py`

------
https://chatgpt.com/codex/tasks/task_e_687f4d2a5a84832f84984c4e293c3b08