### PR TITLE
Support multi-cabinet lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Describe each subject with its teachers and lesson structure.
 - `teachers` – teachers who can teach the subject
 - `primaryTeachers` – teachers that must be present
 - `requiredTeachers` – number of teachers needed for each lesson
-- `optimalSlot` – preferred starting slot
+- `requiredCabinets` – number of rooms needed for each lesson
+ - `optimalSlot` – preferred starting slot
 - `classes` – list of lesson lengths that must occur on separate days
 - `allowPermutations` – allow the lesson order to change
 - `avoidConsecutive` – try not to schedule on back-to-back days

--- a/config-example.json
+++ b/config-example.json
@@ -44,7 +44,7 @@
     "DP1_Mathematics_HL": { "teachers": ["Alex"], "optimalSlot": 0, "classes": [2, 2, 1], "comment": "Higher‑level math needs peak cognitive resources available right at the start of the day." },
 
     "DP1_Chemistry_SL": { "teachers": ["Olga", "Bob"], "optimalSlot": 1, "classes": [2, 1], "comment": "Hands‑on labs benefit from high alertness that persists through the second morning slot." },
-    "DP1_Chemistry_HL": { "teachers": ["Olga", "Bob", "Greg"], "primaryTeachers": ["Olga"], "requiredTeachers": 2, "optimalSlot": 1, "classes": [2], "comment": "Advanced chemistry calculations need strong focus still available early in the day." }
+    "DP1_Chemistry_HL": { "teachers": ["Olga", "Bob", "Greg"], "primaryTeachers": ["Olga"], "requiredTeachers": 2, "requiredCabinets": 2, "optimalSlot": 1, "classes": [2], "comment": "Advanced chemistry calculations need strong focus still available early in the day." }
   },
 
   "teachers": {


### PR DESCRIPTION
## Summary
- add `requiredCabinets` option for subjects in example config
- document the new parameter
- update scheduler to reserve multiple rooms and export them
- adjust HTML rendering for multiple cabinets

## Testing
- `python -m py_compile newSchedule.py`


------
https://chatgpt.com/codex/tasks/task_e_687fa0ec21b0832f9d25ea2226ec08ba