### PR TITLE
Fix cabinet capacity for multiple rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ Describe each subject with its teachers and lesson structure.
 - `teachers` – teachers who can teach the subject
 - `primaryTeachers` – teachers that must be present
 - `requiredTeachers` – number of teachers needed for each lesson
-- `requiredCabinets` – number of rooms needed for each lesson
+- `requiredCabinets` – number of rooms needed for each lesson. When more than one
+  cabinet is selected the combined capacity of all chosen rooms must fit the
+  class size
  - `optimalSlot` – preferred starting slot
 - `classes` – list of lesson lengths that must occur on separate days
 - `allowPermutations` – allow the lesson order to change


### PR DESCRIPTION
## Summary
- validate total capacity when parsing fixed lessons
- support subjects needing multiple cabinets by checking total capacity
- enforce the capacity constraint in CP-SAT model
- document cabinet capacity requirement in README

## Testing
- `python newSchedule.py config-example.json >/tmp/test.log` *(fails: ModuleNotFoundError: No module named 'ortools')*

------
https://chatgpt.com/codex/tasks/task_e_687fa5b6e2c8832fb4fb8be5c4bbc1ab