### PR TITLE
Add allowedSubjects for cabinets

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ List the days of teaching and available lesson numbers:
 ```
 
 ### cabinets
-Rooms where classes may take place. Each entry defines a capacity:
+Rooms where classes may take place. Each entry defines a capacity and optional
+list of subjects allowed in that room:
 ```json
-"Room 101": {"capacity": 20}
+"Room 101": {"capacity": 20, "allowedSubjects": ["Chemistry"]}
 ```
 
 ### subjects

--- a/config-example.json
+++ b/config-example.json
@@ -32,8 +32,8 @@
   "cabinets": {
     "Room #001": { "capacity": 20 },
     "Room #002": { "capacity": 20 },
-    "Room #003": { "capacity": 10 },
-    "Room #004": { "capacity": 5  }
+    "Room #003": { "capacity": 10, "allowedSubjects": ["DP1_Chemistry_SL"] },
+    "Room #004": { "capacity": 5,  "allowedSubjects": ["DP1_Chemistry_HL"] }
   },
 
   "subjects": {


### PR DESCRIPTION
## Summary
- support optional `allowedSubjects` for cabinets
- document the new field
- update example configuration

## Testing
- `python -m py_compile newSchedule.py`
- `python newSchedule.py config-example.json schedule.json schedule.html` *(fails: ModuleNotFoundError)*
- `pip install ortools` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_687fc09e3ef0832f81525bbfb498cab0