### PR TITLE
Add optional printName parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ list of subjects allowed in that room:
 ```json
 "Room 101": {"capacity": 20, "allowedSubjects": ["Chemistry"]}
 ```
+Optional field `printName` overrides the key when shown in reports.
 
 ### subjects
 Describe each subject with its teachers and lesson structure.
@@ -131,6 +132,7 @@ Describe each subject with its teachers and lesson structure.
 - `allowPermutations` – allow the lesson order to change
 - `avoidConsecutive` – try not to schedule on back-to-back days
 - `cabinets` – rooms where the lesson may take place
+- `printName` – optional name to display in reports
 
 ### teachers
 Mapping of teacher names to optional settings.
@@ -138,6 +140,7 @@ Mapping of teacher names to optional settings.
 - `arriveEarly` – whether the teacher is present from slot `0`
 - `allowedSlots` – specific slots when the teacher can work
 - `forbiddenSlots` – slots the teacher cannot work
+- `printName` – optional name used in reports
 
 ### students
 List of students with their subjects and optional settings.

--- a/config-example.json
+++ b/config-example.json
@@ -30,14 +30,14 @@
   ],
 
   "cabinets": {
-    "Room #001": { "capacity": 20 },
+    "Room #001": { "capacity": 20, "printName": "Auditorium 1" },
     "Room #002": { "capacity": 20 },
     "Room #003": { "capacity": 10, "allowedSubjects": ["DP1_Chemistry_SL"] },
     "Room #004": { "capacity": 5,  "allowedSubjects": ["DP1_Chemistry_HL"] }
   },
 
   "subjects": {
-    "DP1_English_Literature_SL": { "teachers": ["Marie", "Helena", "Jane"], "primaryTeachers": ["Marie"], "requiredTeachers": 2, "optimalSlot": 4, "classes": [2, 1], "avoidConsecutive": false, "allowPermutations": false, "cabinets": ["Room #001", "Room #002"], "comment": "Literary analysis benefits from stabilized verbal processing later in the day." },
+    "DP1_English_Literature_SL": { "printName": "English Lit SL", "teachers": ["Marie", "Helena", "Jane"], "primaryTeachers": ["Marie"], "requiredTeachers": 2, "optimalSlot": 4, "classes": [2, 1], "avoidConsecutive": false, "allowPermutations": false, "cabinets": ["Room #001", "Room #002"], "comment": "Literary analysis benefits from stabilized verbal processing later in the day." },
     "DP1_English_Literature_HL": { "teachers": ["Marie", "Helena", "Jane"], "optimalSlot": 4, "classes": [2, 2, 1], "comment": "Extended essay work and close reading profit from early‑afternoon linguistic focus." },
 
     "DP1_Mathematics_SL": { "teachers": ["Alex", "Greg"], "optimalSlot": 0, "classes": [2, 1], "allowPermutations": false, "comment": "Problem‑solving is strongest first period when working‑memory and alertness are freshest." },
@@ -49,6 +49,7 @@
 
   "teachers": {
     "Marie": {
+      "printName": "Mrs. Marie",
       "importance": 50,
       "arriveEarly": true,
       "allowedSlots": { "Tuesday": [], "Thursday": [4,5,6,7], "Friday": [] },
@@ -61,7 +62,7 @@
       "forbiddenSlots": { "Friday": [5,6] }
     },
 
-    "Alex": {},
+    "Alex": { "printName": "Mr. Alex" },
     "Greg": {},
 
     "Olga": {},


### PR DESCRIPTION
## Summary
- support `printName` field for teachers, subjects and cabinets
- show `printName` in console output and HTML if provided
- document the new option in README
- extend example config with a few `printName` entries

## Testing
- `python -m py_compile newSchedule.py`

------
https://chatgpt.com/codex/tasks/task_e_687fca0bdf30832fab446fd4828fa50e