### PR TITLE
Fix teacher alias lookup

### DIFF
--- a/newSchedule.py
+++ b/newSchedule.py
@@ -1409,6 +1409,10 @@ def render_schedule(schedule: Dict[str, Any], cfg: Dict[str, Any]) -> None:
         sid: info.get("printName", info.get("name", sid))
         for sid, info in cfg.get("subjects", {}).items()
     }
+    teacher_names = {
+        t["name"]: t.get("printName", t.get("name", t["name"]))
+        for t in cfg.get("teachers", [])
+    }
     student_size = {s["name"]: int(s.get("group", 1)) for s in cfg.get("students", [])}
 
     print()


### PR DESCRIPTION
## Summary
- prevent crash in `render_schedule`

## Testing
- `python3 -m py_compile newSchedule.py`

------
https://chatgpt.com/codex/tasks/task_e_687fd307c424832fbdf01e95f761a3a4