### PR TITLE
Add optional length for fixed lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ List of students with their subjects and optional settings.
 - `forbiddenSlots` – slots the student cannot attend
 
 ### lessons
-Optional fixed lessons specified as `[day, slot, subject, room, [teachers]]` to lock classes to certain times.
+Optional fixed lessons specified as `[day, slot, subject, room, [teachers], length]` to lock
+classes to certain times. `length` is optional and must match one of the subject's defined
+class lengths when provided.
 
 ### model (optional)
 - `maxTime` – solving time limit in seconds (default three hours). A larger value can improve results but takes longer

--- a/config-example.json
+++ b/config-example.json
@@ -93,7 +93,7 @@
   ],
 
   "lessons": [
-    ["Monday", 1, "DP1_English_Literature_SL", "Room #002", ["Marie", "Jane"]]
+    ["Monday", 1, "DP1_English_Literature_SL", "Room #002", ["Marie", "Jane"], 2]
   ],
 
   "model": {


### PR DESCRIPTION
## Summary
- allow fixed lesson length as optional final argument
- document optional length parameter in README
- adapt config example to new lessons format
- fit classes automatically to day length when no explicit length

## Testing
- `python3 -m py_compile newSchedule.py`
- `python3 newSchedule.py config-example.json /tmp/schedule.json -y` *(fails: ModuleNotFoundError: No module named 'ortools')*

------
https://chatgpt.com/codex/tasks/task_e_687fd5d8e07c832fb718131c604b60b4