### PR TITLE
Add support for optional teachers in fixed lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,10 @@ List of students with their subjects and optional settings.
 - `forbiddenSlots` – slots the student cannot attend
 
 ### lessons
-Optional fixed lessons specified as `[day, slot, subject, room, [teachers], length]` to lock
-classes to certain times. `length` is optional and must match one of the subject's defined
-class lengths when provided.
+Optional fixed lessons specified as `[day, slot, subject, room, teachers?, length?]` to lock
+classes to certain times. The `teachers` element may be omitted, `null` or an empty array
+to let the solver pick the best available teachers. `length` is optional and must match one
+of the subject's defined class lengths when provided.
 
 ### model (optional)
 - `maxTime` – solving time limit in seconds (default three hours). A larger value can improve results but takes longer

--- a/config-example.json
+++ b/config-example.json
@@ -93,7 +93,7 @@
   ],
 
   "lessons": [
-    ["Monday", 1, "DP1_English_Literature_SL", "Room #002", ["Marie", "Jane"], 2]
+    ["Monday", 1, "DP1_English_Literature_SL", "Room #002", null, 2]
   ],
 
   "model": {


### PR DESCRIPTION
## Summary
- allow lesson entries without teachers and parse optional teachers
- validate fixed lessons when teachers are missing
- restrict available teachers for fixed slots and leave assignment to solver
- document optional teachers in README
- update example config to show null teacher list

## Testing
- `python -m py_compile newSchedule.py`

------
https://chatgpt.com/codex/tasks/task_e_687ff230d2e8832fa28dd491abc74b14