### PR TITLE
Setup skeleton for fast scheduling pipeline

### DIFF
--- a/doSchedule.py
+++ b/doSchedule.py
@@ -1,0 +1,38 @@
+"""Entry point for the new fast scheduling pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Optional
+
+from fast.preprocessing import preprocess
+from fast.model import build_feasible_model, build_optimized_model
+from fast.search import solve_model
+from newSchedule import generate_html
+
+
+def run(config_path: str, html_path: str | None = None) -> None:
+    """Run preprocessing, solving and report generation."""
+    data = preprocess(config_path)
+    model = build_feasible_model(data)
+    solver = solve_model(model)
+    if solver is None:
+        raise RuntimeError("No feasible schedule found")
+    model = build_optimized_model(model, data)
+    solver = solve_model(model)
+    if solver is None:
+        raise RuntimeError("Optimisation failed")
+    html = html_path or "schedule.html"
+    generate_html({}, data.config, html)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="School schedule optimiser")
+    parser.add_argument("config", nargs="?", default="schedule-config.json")
+    parser.add_argument("html", nargs="?", default="schedule.html")
+    args = parser.parse_args(argv)
+    run(args.config, args.html)
+
+
+if __name__ == "__main__":
+    main()

--- a/fast/__init__.py
+++ b/fast/__init__.py
@@ -1,0 +1,8 @@
+"""Fast scheduling modules."""
+
+__all__ = [
+    "preprocess",
+    "build_feasible_model",
+    "build_optimized_model",
+    "solve_model",
+]

--- a/fast/model.py
+++ b/fast/model.py
@@ -1,0 +1,27 @@
+"""Model construction helpers for the scheduling problem."""
+
+from typing import Any
+from ortools.sat.python import cp_model
+
+from .preprocessing import PreprocessedData
+
+
+class ScheduleModel:
+    """Wrapper around a CP-SAT model and its variables."""
+
+    def __init__(self) -> None:
+        self.model = cp_model.CpModel()
+        # TODO: store intervals and helper variables
+
+
+def build_feasible_model(data: PreprocessedData) -> ScheduleModel:
+    """Build a basic model that only enforces hard constraints."""
+    sched = ScheduleModel()
+    # TODO: convert `data` into interval variables
+    return sched
+
+
+def build_optimized_model(base: ScheduleModel, data: PreprocessedData) -> ScheduleModel:
+    """Extend the base model with soft constraints and objectives."""
+    # TODO: add penalties and objective function
+    return base

--- a/fast/preprocessing.py
+++ b/fast/preprocessing.py
@@ -1,0 +1,26 @@
+"""Preprocessing utilities for the scheduling model."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+import json
+
+
+@dataclass
+class PreprocessedData:
+    """Container for preprocessed schedule configuration."""
+
+    config: Dict[str, Any]
+
+
+def load_config(path: str = "schedule-config.json") -> Dict[str, Any]:
+    """Load raw configuration from a JSON file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def preprocess(path: str = "schedule-config.json") -> PreprocessedData:
+    """Perform basic preprocessing and return structured data."""
+    cfg = load_config(path)
+    # TODO: add domain filtering and ID remapping
+    return PreprocessedData(config=cfg)

--- a/fast/search.py
+++ b/fast/search.py
@@ -1,0 +1,17 @@
+"""Solver routines for the scheduling model."""
+
+from typing import Optional
+from ortools.sat.python import cp_model
+
+from .model import ScheduleModel
+
+
+def solve_model(sched: ScheduleModel, *, time_limit: Optional[int] = None) -> Optional[cp_model.CpSolver]:
+    """Solve the provided model and return the solver instance."""
+    solver = cp_model.CpSolver()
+    if time_limit:
+        solver.parameters.max_time_in_seconds = time_limit
+    result = solver.Solve(sched.model)
+    if result not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        return None
+    return solver


### PR DESCRIPTION
## Summary
- add `fast` package with preprocessing, model and search skeletons
- create `doSchedule.py` orchestrator that chains preprocessing and solving
- expose placeholder APIs in `fast/__init__.py`

## Testing
- `python -m py_compile doSchedule.py fast/*.py newSchedule.py`

------
https://chatgpt.com/codex/tasks/task_e_688089e70f74832f9fc06dd2c3839e27