### PR TITLE
Enable comments in JSON configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ Inside the project folder make a copy of `config-example.json` and name it `sche
 2. Right click the file and choose **Duplicate** if you want an extra backup.
 3. Edit the file with **TextEdit** or the free [Sublime Text](https://www.sublimetext.com/).
 4. Save the file with **⌘S**.
+5. You can include comments in the JSON using `//`, `#` or `/* */`; they will be ignored when the program loads the file.
 
 **Editing on Windows**
 1. Use File Explorer to open the project folder.
 2. Right click `schedule-config.json` and choose **Copy**, then **Paste** to keep a spare copy.
 3. Edit the file with **Notepad**, [Notepad++](https://notepad-plus-plus.org/) or [Sublime Text](https://www.sublimetext.com/).
 4. Use **File → Save** when done.
+5. Comments starting with `//`, `#` or enclosed in `/* */` are allowed and ignored during loading.
 
 ### 5. Run the scheduler
 
@@ -87,6 +89,7 @@ Press **Ctrl+C** to stop early; the best solution so far will be saved. The sear
 ## Configuration overview
 
 The configuration file is divided into several sections. Values are stored as `[value, "description"]` pairs. The **settings**, **defaults** and **penalties** blocks are required. The **model** block is optional and should only be changed if you understand the effects.
+You may add comments using `//`, `#` or `/* */`; they are stripped when the file is read.
 
 ### settings (required)
 - **objective** – `"total"` minimises the sum of all penalties; `"fair"` balances penalties between teachers and students; `"check"` only tests if any schedule is possible. *(default `"total"`)*

--- a/fast/preprocessing.py
+++ b/fast/preprocessing.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Tuple
 import json
+import re
 
 
 @dataclass
@@ -20,7 +21,9 @@ class PreprocessedData:
 def load_config(path: str = "schedule-config.json") -> Dict[str, Any]:
     """Load raw configuration from a JSON file."""
     with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        text = fh.read()
+    text = re.sub(r"//.*?$|#.*?$|/\*.*?\*/", "", text, flags=re.MULTILINE | re.DOTALL)
+    return json.loads(text)
 
 
 def filter_domains(cfg: Dict[str, Any]) -> None:

--- a/newSchedule.py
+++ b/newSchedule.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 import copy
 from collections import defaultdict
@@ -22,10 +23,17 @@ def _detect_duplicates(entities: List[Dict[str, Any]], key_fields: List[str]) ->
     return [names for names in groups.values() if len(names) > 1]
 
 
+def _load_json_with_comments(path: str) -> Dict[str, Any]:
+    """Return parsed JSON allowing //, # and /* */ comments."""
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    text = re.sub(r"//.*?$|#.*?$|/\*.*?\*/", "", text, flags=re.MULTILINE | re.DOTALL)
+    return json.loads(text)
+
+
 def load_config(path: str = "schedule-config.json") -> Dict[str, Any]:
     """Load configuration file and apply defaults."""
-    with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
+    data = _load_json_with_comments(path)
 
     settings = data.get("settings", {})
     defaults = data.get("defaults", {})


### PR DESCRIPTION
## Summary
- allow `//`, `#` and `/* */` style comments in configuration files
- document the feature in README

## Testing
- `python -m py_compile newSchedule.py fast/preprocessing.py`

------
https://chatgpt.com/codex/tasks/task_e_68825b8eefd8832f98776581095f96d5