### PR TITLE
Add fast solving mode

### DIFF
--- a/newSchedule.py
+++ b/newSchedule.py
@@ -246,6 +246,276 @@ def _init_schedule(
     return schedule
 
 
+def solve_fast(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Solve using the simplified fast model."""
+    schedule, total = build_fast_model(cfg)
+    export = {"days": []}
+    for day in cfg["days"]:
+        dname = day["name"]
+        slot_list = []
+        for slot in day["slots"]:
+            slot_list.append(
+                {
+                    "slotIndex": slot,
+                    "classes": schedule[dname][slot],
+                    "gaps": {"students": [], "teachers": []},
+                    "home": {"students": [], "teachers": []},
+                    "penalty": {},
+                    "penaltyDetails": [],
+                }
+            )
+        export["days"].append({"name": dname, "slots": slot_list})
+    export["totalPenalty"] = total
+    return export
+
+
+def build_fast_model(cfg: Dict[str, Any]) -> tuple[Dict[str, Dict[int, List[Dict[str, Any]]]], int]:
+    """Construct and solve a simplified model optimised for speed."""
+    days = cfg["days"]
+    subjects = cfg["subjects"]
+    teachers = cfg.get("teachers", [])
+    students = cfg.get("students", [])
+    cabinets = cfg.get("cabinets", {})
+
+    day_index = {d["name"]: idx for idx, d in enumerate(days)}
+    max_slots = max(max(d["slots"]) for d in days) + 1
+
+    # availability maps
+    teacher_limits = {
+        t["name"]: {d["name"]: set(d["slots"]) for d in days} for t in teachers
+    }
+    for t in teachers:
+        name = t["name"]
+        for day in days:
+            dname = day["name"]
+            slots = set(day["slots"])
+            if dname in t.get("allowedSlots", {}):
+                slots &= set(t["allowedSlots"][dname])
+            if dname in t.get("forbiddenSlots", {}):
+                slots -= set(t["forbiddenSlots"][dname])
+            teacher_limits[name][dname] = slots
+
+    student_limits = {
+        s["name"]: {d["name"]: set(d["slots"]) for d in days} for s in students
+    }
+    for s in students:
+        name = s["name"]
+        for day in days:
+            dname = day["name"]
+            slots = set(day["slots"])
+            if dname in s.get("allowedSlots", {}):
+                slots &= set(s["allowedSlots"][dname])
+            if dname in s.get("forbiddenSlots", {}):
+                slots -= set(s["forbiddenSlots"][dname])
+            student_limits[name][dname] = slots
+
+    students_by_subject: Dict[str, List[str]] = defaultdict(list)
+    for stu in students:
+        for sid in stu.get("subjects", []):
+            students_by_subject[sid].append(stu["name"])
+
+    student_size = {s["name"]: int(s.get("group", 1)) for s in students}
+
+    # helper selectors
+    def select_teachers(subj: Dict[str, Any]) -> List[str]:
+        req = int(subj.get("requiredTeachers", 1))
+        chosen: List[str] = list(subj.get("primaryTeachers", []))
+        for t in subj.get("teachers", []):
+            if t not in chosen:
+                chosen.append(t)
+            if len(chosen) >= req:
+                break
+        if len(chosen) < req:
+            raise ValueError(f"Not enough teachers for subject {subj}")
+        return chosen[:req]
+
+    def select_cabinets(subj: Dict[str, Any]) -> List[str]:
+        req = int(subj.get("requiredCabinets", 1))
+        opts = subj.get("cabinets", list(cabinets))
+        if len(opts) < req:
+            raise ValueError(f"Not enough cabinets for subject {subj}")
+        return list(opts)[:req]
+
+    # map fixed lessons to specific class indices
+    remaining_idx = {
+        sid: list(range(len(info.get("classes", [])))) for sid, info in subjects.items()
+    }
+    class_len = {sid: info.get("classes", []) for sid, info in subjects.items()}
+    fixed: Dict[tuple, Dict[str, Any]] = {}
+    for entry in cfg.get("lessons", []):
+        sid = entry["subject"]
+        d_idx = day_index[entry["day"]]
+        slot = int(entry["slot"])
+        ln = entry.get("length")
+        choices = remaining_idx[sid]
+        chosen = None
+        if ln is not None:
+            for i in choices:
+                if class_len[sid][i] == ln:
+                    chosen = i
+                    break
+        if chosen is None:
+            chosen = choices[0]
+        remaining_idx[sid].remove(chosen)
+        fixed[(sid, chosen)] = {
+            "day_idx": d_idx,
+            "slot": slot,
+            "teachers": entry.get("teachers"),
+            "cabinets": entry.get("cabinets"),
+            "length": class_len[sid][chosen],
+        }
+
+    model = cp_model.CpModel()
+    teacher_intervals: Dict[str, List[cp_model.IntervalVar]] = defaultdict(list)
+    student_intervals: Dict[str, List[cp_model.IntervalVar]] = defaultdict(list)
+    room_intervals: Dict[str, List[cp_model.IntervalVar]] = defaultdict(list)
+    classes = []
+
+    for sid, subj in subjects.items():
+        teach_list = select_teachers(subj)
+        room_list = select_cabinets(subj)
+        lengths = subj.get("classes", [])
+        enrolled = students_by_subject.get(sid, [])
+        class_cap = sum(student_size[s] for s in enrolled)
+        if sum(cabinets[r]["capacity"] for r in room_list) < class_cap:
+            raise ValueError(f"Cabinets too small for subject {sid}")
+
+        for idx, length in enumerate(lengths):
+            if (sid, idx) in fixed:
+                f = fixed[(sid, idx)]
+                day_pairs = [(f["day_idx"], int(f["slot"]))]
+                t_used = f.get("teachers") or teach_list
+                r_used = f.get("cabinets") or room_list
+            else:
+                day_pairs = []
+                t_used = teach_list
+                r_used = room_list
+                for d_idx, day in enumerate(days):
+                    last = day["slots"][-1]
+                    for start in day["slots"]:
+                        if start + length - 1 > last:
+                            continue
+                        if any(
+                            start + k not in teacher_limits[t][day["name"]]
+                            for t in t_used
+                            for k in range(length)
+                        ):
+                            continue
+                        if any(
+                            start + k not in student_limits[s][day["name"]]
+                            for s in enrolled
+                            for k in range(length)
+                        ):
+                            continue
+                        day_pairs.append((d_idx, start))
+            if not day_pairs:
+                raise RuntimeError(f"No slot for {sid} class {idx}")
+
+            day_var = model.NewIntVar(0, len(days) - 1, f"day_{sid}_{idx}")
+            slot_var = model.NewIntVar(0, max_slots - 1, f"slot_{sid}_{idx}")
+            model.AddAllowedAssignments([day_var, slot_var], day_pairs)
+            start_gl = model.NewIntVar(0, len(days) * max_slots, f"start_{sid}_{idx}")
+            model.Add(start_gl == day_var * max_slots + slot_var)
+            end_gl = model.NewIntVar(0, len(days) * max_slots, f"end_{sid}_{idx}")
+            model.Add(end_gl == start_gl + length)
+            interval = model.NewIntervalVar(start_gl, length, end_gl, f"int_{sid}_{idx}")
+
+            info = {
+                "sid": sid,
+                "idx": idx,
+                "length": length,
+                "day_var": day_var,
+                "slot_var": slot_var,
+                "interval": interval,
+                "teachers": t_used,
+                "students": enrolled,
+                "cabinets": r_used,
+            }
+            classes.append(info)
+            for t in t_used:
+                teacher_intervals[t].append(interval)
+            for s in enrolled:
+                student_intervals[s].append(interval)
+            for r in r_used:
+                room_intervals[r].append(interval)
+
+    for ivals in teacher_intervals.values():
+        if len(ivals) > 1:
+            model.AddNoOverlap(ivals)
+    for ivals in student_intervals.values():
+        if len(ivals) > 1:
+            model.AddNoOverlap(ivals)
+    for ivals in room_intervals.values():
+        if len(ivals) > 1:
+            model.AddNoOverlap(ivals)
+
+    last_teacher: Dict[tuple, cp_model.IntVar] = {}
+    for t in teacher_intervals:
+        for d in range(len(days)):
+            var = model.NewIntVar(0, max_slots, f"lt_{t}_{d}")
+            bounds = []
+            for c in classes:
+                if t in c["teachers"]:
+                    b = model.NewBoolVar(f"ltb_{t}_{c['sid']}_{c['idx']}_{d}")
+                    model.Add(c["day_var"] == d).OnlyEnforceIf(b)
+                    model.Add(c["day_var"] != d).OnlyEnforceIf(b.Not())
+                    model.Add(var >= c["slot_var"] + c["length"]).OnlyEnforceIf(b)
+                    bounds.append(b)
+            if not bounds:
+                model.Add(var == 0)
+            last_teacher[(t, d)] = var
+
+    last_student: Dict[tuple, cp_model.IntVar] = {}
+    for s in student_intervals:
+        for d in range(len(days)):
+            var = model.NewIntVar(0, max_slots, f"ls_{s}_{d}")
+            bounds = []
+            for c in classes:
+                if s in c["students"]:
+                    b = model.NewBoolVar(f"lsb_{s}_{c['sid']}_{c['idx']}_{d}")
+                    model.Add(c["day_var"] == d).OnlyEnforceIf(b)
+                    model.Add(c["day_var"] != d).OnlyEnforceIf(b.Not())
+                    model.Add(var >= c["slot_var"] + c["length"]).OnlyEnforceIf(b)
+                    bounds.append(b)
+            if not bounds:
+                model.Add(var == 0)
+            last_student[(s, d)] = var
+
+    obj_terms = list(last_teacher.values()) + [last_student[(s, d)] * student_size[s] for (s, d) in last_student]
+    model.Minimize(sum(obj_terms))
+
+    solver = cp_model.CpSolver()
+    params = cfg.get("model", {})
+    solver.parameters.max_time_in_seconds = params.get("maxTime", DEFAULT_MAX_TIME)
+    solver.parameters.num_search_workers = params.get("workers", DEFAULT_WORKERS)
+    solver.parameters.log_search_progress = params.get("showProgress", DEFAULT_SHOW_PROGRESS)
+
+    status = solver.Solve(model)
+    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        raise RuntimeError("No feasible schedule found")
+
+    schedule = _init_schedule(days)
+    for c in classes:
+        d_idx = solver.Value(c["day_var"])
+        dname = days[d_idx]["name"]
+        start = solver.Value(c["slot_var"])
+        size = sum(student_size[s] for s in c["students"])
+        for s in range(start, start + c["length"]):
+            schedule[dname][s].append(
+                {
+                    "subject": c["sid"],
+                    "teachers": c["teachers"],
+                    "cabinets": c["cabinets"],
+                    "students": c["students"],
+                    "size": size,
+                    "start": start,
+                    "length": c["length"],
+                }
+            )
+
+    return schedule, int(solver.ObjectiveValue())
+
+
 def _prepare_fixed_classes(
     cfg: Dict[str, Any],
     teacher_limits: Dict[str, Dict[str, Set[int]]],
@@ -2640,7 +2910,10 @@ def main() -> None:
         with open(out_path, "r", encoding="utf-8") as fh:
             result = json.load(fh)
     else:
-        result = solve(cfg)
+        if obj_mode == "fast":
+            result = solve_fast(cfg)
+        else:
+            result = solve(cfg)
         with open(out_path, "w", encoding="utf-8") as fh:
             json.dump(result, fh, ensure_ascii=False, indent=2)
         print(f"Schedule written to {out_path}")


### PR DESCRIPTION
## Summary
- add build_fast_model to construct simplified CP-SAT model
- add solve_fast that returns export based on fast model
- call fast solver when `settings.objective` is `fast`

## Testing
- `python -m py_compile newSchedule.py` *(fails: ModuleNotFoundError for ortools when attempting runtime; dependency installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68828ee0a49c832f98e27d43dd7120bc