### PR TITLE
Implement simplified fast schedule model

### DIFF
--- a/newSchedule.py
+++ b/newSchedule.py
@@ -1440,6 +1440,355 @@ def solve(cfg: Dict[str, Any]) -> Dict[str, Any]:
     return export
 
 
+def build_fast_model(cfg: Dict[str, Any]) -> Dict[str, Dict[int, List[Dict[str, Any]]]]:
+    """Construct a simplified schedule model focused on end times."""
+    days = cfg["days"]
+    subjects = cfg["subjects"]
+    teachers = cfg.get("teachers", [])
+    students = cfg.get("students", [])
+    cabinets = cfg.get("cabinets", {})
+
+    teacher_names = [t["name"] for t in teachers]
+    teacher_map = {t["name"]: set(t.get("subjects", [])) for t in teachers}
+
+    # allowed slots for each teacher
+    teacher_limits: Dict[str, Dict[str, Set[int]]] = {}
+    for t in teachers:
+        name = t["name"]
+        allow = t.get("allowedSlots")
+        forbid = t.get("forbiddenSlots")
+        avail: Dict[str, Set[int]] = {}
+        for day in days:
+            dname = day["name"]
+            slots_set = set(day["slots"])
+            if allow is not None:
+                if dname in allow:
+                    al = allow[dname]
+                    allowed = slots_set.copy() if not al else set(al)
+                else:
+                    allowed = set()
+            else:
+                allowed = slots_set.copy()
+            if forbid is not None and dname in forbid:
+                fb = forbid[dname]
+                if not fb:
+                    allowed = set()
+                else:
+                    allowed -= set(fb)
+            avail[dname] = allowed
+        teacher_limits[name] = avail
+
+    # allowed slots for each student
+    student_limits: Dict[str, Dict[str, Set[int]]] = {}
+    students_by_subject: Dict[str, List[str]] = {}
+    student_size: Dict[str, int] = {}
+    for stu in students:
+        name = stu["name"]
+        allow = stu.get("allowedSlots")
+        forbid = stu.get("forbiddenSlots")
+        avail: Dict[str, Set[int]] = {}
+        for day in days:
+            dname = day["name"]
+            slots_set = set(day["slots"])
+            if allow is not None:
+                if dname in allow:
+                    al = allow[dname]
+                    allowed = slots_set.copy() if not al else set(al)
+                else:
+                    allowed = set()
+            else:
+                allowed = slots_set.copy()
+            if forbid is not None and dname in forbid:
+                fb = forbid[dname]
+                if not fb:
+                    allowed = set()
+                else:
+                    allowed -= set(fb)
+            avail[dname] = allowed
+        student_limits[name] = avail
+
+        student_size[name] = int(stu.get("group", 1))
+        for sid in stu.get("subjects", []):
+            students_by_subject.setdefault(sid, []).append(name)
+
+    fixed_classes = _prepare_fixed_classes(
+        cfg,
+        teacher_limits,
+        teacher_map,
+        student_limits,
+        students_by_subject,
+        student_size,
+    )
+
+    max_slots = max(len(d["slots"]) for d in days)
+    day_index = {d["name"]: i for i, d in enumerate(days)}
+
+    model = cp_model.CpModel()
+
+    teacher_intervals: Dict[str, List[cp_model.IntervalVar]] = {t: [] for t in teacher_names}
+    student_intervals: Dict[str, List[cp_model.IntervalVar]] = {s["name"]: [] for s in students}
+    cabinet_intervals: Dict[str, List[cp_model.IntervalVar]] = {c: [] for c in cabinets}
+
+    teacher_last: Dict[tuple, cp_model.IntVar] = {}
+    for t in teacher_names:
+        for d in range(len(days)):
+            teacher_last[(t, d)] = model.NewIntVar(0, max_slots, f"last_{t}_{d}")
+
+    student_last: Dict[tuple, cp_model.IntVar] = {}
+    for s in students:
+        name = s["name"]
+        for d in range(len(days)):
+            student_last[(name, d)] = model.NewIntVar(0, max_slots, f"last_{name}_{d}")
+
+    class_vars = {}
+
+    def gindex(day_idx: int, slot: int) -> int:
+        return day_idx * max_slots + slot
+
+    for sid, subj in subjects.items():
+        lengths = subj.get("classes", [])
+        allowed_teachers = [t for t in teacher_map if sid in teacher_map[t]]
+        required_teachers = int(subj.get("requiredTeachers", 1))
+        primary = set(subj.get("primaryTeachers", []))
+
+        allowed_cabs = [
+            c
+            for c in subj.get("cabinets", list(cabinets))
+            if not cabinets.get(c, {}).get("allowedSubjects")
+            or sid in cabinets[c]["allowedSubjects"]
+        ]
+        required_cabs = int(subj.get("requiredCabinets", 1))
+        class_size = sum(student_size[s] for s in students_by_subject.get(sid, []))
+        allowed_cabs = [c for c in allowed_cabs if cabinets[c]["capacity"] >= class_size]
+
+        students_list = students_by_subject.get(sid, [])
+
+        # precompute common student slots per day
+        common_slots: Dict[str, Set[int]] = {}
+        for d in days:
+            dname = d["name"]
+            slots = set(d["slots"])
+            for stu in students_list:
+                slots &= student_limits[stu][dname]
+            common_slots[dname] = slots
+
+        for idx, length in enumerate(lengths):
+            key = (sid, idx)
+            if key in fixed_classes:
+                fixed = fixed_classes[key]
+                dname = fixed["day"]
+                d_idx = day_index[dname]
+                start = fixed["start"]
+                start_var = model.NewConstant(gindex(d_idx, start))
+                day_var = model.NewConstant(d_idx)
+                slot_var = model.NewConstant(start)
+                t_choices = fixed["available_teachers"]
+                cab_choices = fixed["cabinets"]
+            else:
+                domain_vals = []
+                for d_idx, day in enumerate(days):
+                    dname = day["name"]
+                    last_slot = day["slots"][-1]
+                    for s in day["slots"]:
+                        if s + length - 1 > last_slot:
+                            continue
+                        if s not in common_slots[dname]:
+                            continue
+                        avail_cnt = sum(
+                            all(k in teacher_limits[t][dname] for k in range(s, s + length))
+                            for t in allowed_teachers
+                        )
+                        if avail_cnt < required_teachers:
+                            continue
+                        domain_vals.append(gindex(d_idx, s))
+                if not domain_vals:
+                    raise RuntimeError(f"No slots available for {sid} class {idx}")
+                domain = cp_model.Domain.FromValues(sorted(domain_vals))
+                start_var = model.NewIntVarFromDomain(domain, f"start_{sid}_{idx}")
+                day_var = model.NewIntVar(0, len(days) - 1, f"day_{sid}_{idx}")
+                slot_var = model.NewIntVar(0, max_slots - 1, f"slot_{sid}_{idx}")
+                model.AddDivisionEquality(day_var, start_var, max_slots)
+                model.AddModuloEquality(slot_var, start_var, max_slots)
+                t_choices = allowed_teachers
+                cab_choices = allowed_cabs
+
+            end_var = model.NewIntVar(0, max_slots - 1, f"end_{sid}_{idx}")
+            model.Add(end_var == slot_var + length - 1)
+
+            teachers_selected: Dict[str, cp_model.BoolVar] = {}
+            for t in t_choices:
+                t_domain_vals = []
+                for d_idx, day in enumerate(days):
+                    dname = day["name"]
+                    last_slot = day["slots"][-1]
+                    for s in day["slots"]:
+                        if s + length - 1 > last_slot:
+                            continue
+                        if all(k in teacher_limits[t][dname] for k in range(s, s + length)):
+                            t_domain_vals.append(gindex(d_idx, s))
+                if not t_domain_vals:
+                    continue
+                t_domain = cp_model.Domain.FromValues(sorted(set(t_domain_vals)))
+                pres = model.NewBoolVar(f"teach_{sid}_{idx}_{t}")
+                t_start = model.NewIntVarFromDomain(t_domain, f"tstart_{sid}_{idx}_{t}")
+                model.Add(t_start == start_var).OnlyEnforceIf(pres)
+                interval = model.NewOptionalIntervalVar(t_start, length, t_start + length, pres,
+                                                        f"tint_{sid}_{idx}_{t}")
+                teacher_intervals[t].append(interval)
+                teachers_selected[t] = pres
+
+            if teachers_selected:
+                model.Add(sum(teachers_selected.values()) == required_teachers)
+                for t in primary:
+                    if t in teachers_selected:
+                        model.Add(teachers_selected[t] == 1)
+            else:
+                if required_teachers > 0:
+                    raise RuntimeError(f"No teachers available for {sid} class {idx}")
+
+            cabinet_selected: Dict[str, cp_model.BoolVar] = {}
+            for c in cab_choices:
+                pres = model.NewBoolVar(f"cab_{sid}_{idx}_{c}")
+                interval = model.NewOptionalIntervalVar(start_var, length, start_var + length, pres,
+                                                        f"cint_{sid}_{idx}_{c}")
+                cabinet_intervals[c].append(interval)
+                cabinet_selected[c] = pres
+            if cabinet_selected:
+                model.Add(sum(cabinet_selected.values()) == required_cabs)
+
+            for stu in students_list:
+                interval = model.NewIntervalVar(start_var, length, start_var + length,
+                                                f"stu_{sid}_{idx}_{stu}")
+                student_intervals[stu].append(interval)
+
+            for t, pres in teachers_selected.items():
+                for d_idx in range(len(days)):
+                    day_eq = model.NewBoolVar(f"dteq_{sid}_{idx}_{t}_{d_idx}")
+                    model.Add(day_var == d_idx).OnlyEnforceIf(day_eq)
+                    model.Add(day_var != d_idx).OnlyEnforceIf(day_eq.Not())
+                    both = model.NewBoolVar(f"both_{sid}_{idx}_{t}_{d_idx}")
+                    model.Add(both <= day_eq)
+                    model.Add(both <= pres)
+                    model.Add(both >= day_eq + pres - 1)
+                    model.Add(teacher_last[(t, d_idx)] >= end_var + 1).OnlyEnforceIf(both)
+
+            for stu in students_list:
+                for d_idx in range(len(days)):
+                    day_eq = model.NewBoolVar(f"dseq_{sid}_{idx}_{stu}_{d_idx}")
+                    model.Add(day_var == d_idx).OnlyEnforceIf(day_eq)
+                    model.Add(day_var != d_idx).OnlyEnforceIf(day_eq.Not())
+                    model.Add(student_last[(stu, d_idx)] >= end_var + 1).OnlyEnforceIf(day_eq)
+
+            class_vars[key] = {
+                "start": start_var,
+                "length": length,
+                "day_var": day_var,
+                "slot_var": slot_var,
+                "teachers": teachers_selected,
+                "cabinets": cabinet_selected,
+                "students": students_list,
+                "size": class_size,
+            }
+
+    for intervals in teacher_intervals.values():
+        if len(intervals) > 1:
+            model.AddNoOverlap(intervals)
+    for intervals in student_intervals.values():
+        if len(intervals) > 1:
+            model.AddNoOverlap(intervals)
+    for intervals in cabinet_intervals.values():
+        if len(intervals) > 1:
+            model.AddNoOverlap(intervals)
+
+    total_penalty = sum(teacher_last.values())
+    for stu in students:
+        name = stu["name"]
+        weight = student_size[name]
+        for d_idx in range(len(days)):
+            total_penalty += student_last[(name, d_idx)] * weight
+
+    model.Minimize(total_penalty)
+
+    model_params = cfg.get("model", {})
+    max_time = model_params.get("maxTime", DEFAULT_MAX_TIME)
+    if isinstance(max_time, list):
+        max_time = max_time[0]
+    workers = model_params.get("workers", DEFAULT_WORKERS)
+    if isinstance(workers, list):
+        workers = workers[0] or DEFAULT_WORKERS
+    show_progress = model_params.get("showProgress", DEFAULT_SHOW_PROGRESS)
+    if isinstance(show_progress, list):
+        show_progress = show_progress[0]
+
+    solver = cp_model.CpSolver()
+    solver.parameters.max_time_in_seconds = max_time
+    solver.parameters.num_search_workers = workers
+    solver.parameters.log_search_progress = show_progress
+
+    status = solver.Solve(model)
+    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        raise RuntimeError("No feasible schedule found")
+
+    schedule = _init_schedule(days)
+    for (sid, idx), info in class_vars.items():
+        start_idx = solver.Value(info["start"])
+        d_idx = start_idx // max_slots
+        slot = start_idx % max_slots
+        day_name = days[d_idx]["name"]
+        teachers_assigned = [
+            t for t, var in info["teachers"].items() if solver.Value(var)
+        ]
+        cabinets_used = [c for c, var in info["cabinets"].items() if solver.Value(var)]
+        for s in range(slot, slot + info["length"]):
+            schedule[day_name][s].append(
+                {
+                    "subject": sid,
+                    "teachers": teachers_assigned,
+                    "cabinets": cabinets_used,
+                    "students": info["students"],
+                    "size": info["size"],
+                    "start": slot,
+                    "length": info["length"],
+                }
+            )
+
+    fast_penalty = 0
+    for (t, d_idx), var in teacher_last.items():
+        fast_penalty += solver.Value(var)
+    for stu in students:
+        name = stu["name"]
+        weight = student_size[name]
+        for d_idx in range(len(days)):
+            fast_penalty += solver.Value(student_last[(name, d_idx)]) * weight
+
+    return schedule, int(fast_penalty)
+
+
+def solve_fast(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Generate schedule using the simplified fast model."""
+    sched, penalty = build_fast_model(cfg)
+
+    export = {"days": []}
+    for day in cfg["days"]:
+        name = day["name"]
+        slots_out = []
+        for slot in day["slots"]:
+            slots_out.append(
+                {
+                    "slotIndex": slot,
+                    "classes": sched[name][slot],
+                    "gaps": {"students": [], "teachers": []},
+                    "home": {"students": [], "teachers": []},
+                    "penalty": {},
+                    "penaltyDetails": [],
+                }
+            )
+        export["days"].append({"name": name, "slots": slots_out})
+    export["totalPenalty"] = penalty
+
+    return export
+
+
 def analyse_teachers(schedule: Dict[str, Any]) -> Dict[str, Any]:
     """Gather statistics about teacher workload."""
     teachers = defaultdict(
@@ -2640,7 +2989,10 @@ def main() -> None:
         with open(out_path, "r", encoding="utf-8") as fh:
             result = json.load(fh)
     else:
-        result = solve(cfg)
+        if obj_mode == "fast":
+            result = solve_fast(cfg)
+        else:
+            result = solve(cfg)
         with open(out_path, "w", encoding="utf-8") as fh:
             json.dump(result, fh, ensure_ascii=False, indent=2)
         print(f"Schedule written to {out_path}")


### PR DESCRIPTION
## Summary
- add `build_fast_model` and `solve_fast` implementing a lightweight CP-SAT model
- use new solver when configuration has `"objective": "fast"`

## Testing
- `python -m py_compile newSchedule.py`

------
https://chatgpt.com/codex/tasks/task_e_68828ee0a49c832f98e27d43dd7120bc