### PR TITLE
Validate teacher and student availability across entire lesson

### DIFF
--- a/newSchedule.py
+++ b/newSchedule.py
@@ -729,10 +729,11 @@ def _prepare_fixed_classes(
             for t in tlist:
                 if t not in teacher_map or sid not in teacher_map[t]:
                     raise ValueError(f"Teacher {t} cannot teach subject {sid}")
-                if slot not in teacher_limits[t][day]:
-                    raise ValueError(
-                        f"Teacher {t} not available at {day} slot {slot} for subject {sid}"
-                    )
+                for off in range(length):
+                    if slot + off not in teacher_limits[t][day]:
+                        raise ValueError(
+                            f"Teacher {t} not available for entire duration starting at {day} slot {slot} for subject {sid}"
+                        )
             available_teachers = tlist
         else:
             available_teachers = [
@@ -747,10 +748,11 @@ def _prepare_fixed_classes(
                 )
 
         for stu in students_by_subject.get(sid, []):
-            if slot not in student_limits[stu][day]:
-                raise ValueError(
-                    f"Student {stu} not available at {day} slot {slot} for subject {sid}"
-                )
+            for off in range(length):
+                if slot + off not in student_limits[stu][day]:
+                    raise ValueError(
+                        f"Student {stu} not available for entire duration starting at {day} slot {slot} for subject {sid}"
+                    )
 
         primary = set(subj.get("primaryTeachers", []))
         if explicit_teachers and primary and not primary.issubset(set(tlist)):


### PR DESCRIPTION
## Summary
- ensure `_prepare_fixed_classes` checks teacher slots for entire lesson duration
- check student slots for the full length as well
- update error texts to mention full duration

## Testing
- `python doSchedule.py via-config_good.json | head -n 20` *(fails: ModuleNotFoundError: No module named 'ortools')*
- `pip install ortools` *(fails: Could not find a version that satisfies the requirement ortools)*

------
https://chatgpt.com/codex/tasks/task_e_6882b9b05768832f98cdd019d31dd6c4