### PR TITLE
Add duplicatesPenalty setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The configuration file is divided into several sections. Values are stored as `[
 ### settings (required)
 - **objective** – `"total"` minimises the sum of all penalties; `"fair"` balances penalties between teachers and students; `"check"` only tests if any schedule is possible. *(default `"total"`)*
 - **teacherAsStudents** – how many student opinions one teacher counts as when calculating penalties. *(default 15)*
+- **duplicatesPenalty** – penalty applied when a teacher or student appears in more than one lesson in the same slot. If greater than zero duplicates are allowed. *(default 0)*
 
 ### defaults (required)
 - **teacherImportance** – base weight for teachers. Higher values make teacher gaps more costly. *(default 20)*

--- a/config-example.json
+++ b/config-example.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "objective": ["total", "Optimisation goal: 'total' minimises all penalties, 'fair' balances penalties between teachers and students."],
-    "teacherAsStudents": [15, "How many student opinions a teacher counts for when calculating penalties"]
+    "teacherAsStudents": [15, "How many student opinions a teacher counts for when calculating penalties"],
+    "duplicatesPenalty": [0, "Penalty for overlapping lessons per teacher or student in a slot; if >0 duplicates are allowed"]
   },
   "defaults": {
     "teacherImportance": [20, "Default teacher weight in penalties. Higher value makes gaps for teachers more expensive."],


### PR DESCRIPTION
## Summary
- allow multiple lessons per slot when `settings.duplicatesPenalty` is set
- penalize overlapping lessons for teachers and students
- document new setting in config and README
- display duplicate penalties in HTML reports

## Testing
- `python -m py_compile newSchedule.py`
- `python newSchedule.py via-config_good.json tmp.json tmp.html -y` *(fails: ModuleNotFoundError: No module named 'ortools')*

------
https://chatgpt.com/codex/tasks/task_e_6882c101f67c832f91fc919efa257db2