### PR TITLE
Fix overlap tracking for optional lessons

### DIFF
--- a/newSchedule.py
+++ b/newSchedule.py
@@ -298,8 +298,10 @@ def _assign_optional(
         dname = day["name"]
         for slot in day["slots"]:
             for cls in schedule[dname][slot]:
+                length = cls.get("length", 1)
                 for st in cls.get("students", []):
-                    taken[st][dname].add(slot)
+                    for off in range(length):
+                        taken[st][dname].add(slot + off)
 
     stats = {n: {"total": 0, "attended": 0, "subjects": {}} for n in student_names}
 


### PR DESCRIPTION
## Summary
- track whole class durations in `_assign_optional`
- ensure optional lessons never overlap with mandatory classes

## Testing
- `python doSchedule.py via-config_good.json` *(fails: ModuleNotFoundError: No module named 'ortools')*

------
https://chatgpt.com/codex/tasks/task_e_6884e39bd1ec832fae276f30d4af9b0c