### PR TITLE
Fix optional subject mapping

### DIFF
--- a/newSchedule.py
+++ b/newSchedule.py
@@ -931,6 +931,7 @@ def build_model(cfg: Dict[str, Any]) -> Dict[str, Dict[int, List[Dict[str, Any]]
     # calculate allowed slots for every student
     student_limits: Dict[str, Dict[str, Set[int]]] = {}
     students_by_subject: Dict[str, List[str]] = {}
+    optional_by_subject: Dict[str, List[str]] = {}
     student_size: Dict[str, int] = {}
     student_arrive = {s["name"]: bool(s.get("arriveEarly", True)) for s in students}
     for stu in students:


### PR DESCRIPTION
## Summary
- initialize `optional_by_subject` in `build_model`

## Testing
- `pip install ortools` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688735a42e40832f9f7e937c67e3b7fb